### PR TITLE
Print trailing newline after version

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,7 +10,7 @@ impl Cli {
         match args.next() {
             Some(arg) => {
                 if arg == "--version" {
-                    print!(env!("CARGO_PKG_VERSION"));
+                    println!(env!("CARGO_PKG_VERSION"));
                     exit(0)
                 }
             }


### PR DESCRIPTION
Without the trailing newline, the shell prompt ends up on the same line as the version.

Error:
user@localhost:\~# basilk --version
0.2.0user@localhost:~#

Expected output:
user@localhost:\~# basilk --version
0.2.0
user@localhost:~#

See https://doc.rust-lang.org/std/macro.print.html#

# test

````
$ cargo build --release
   ...
   Compiling basilk v0.2.0 (/home/user/basilk)
    Finished `release` profile [optimized] target(s) in 31.93s

$ ./target/release/basilk --version
0.2.0
````