### PR TITLE
Use GitHub Action to lint Rust

### DIFF
--- a/.github/workflows/lint_rust.yaml
+++ b/.github/workflows/lint_rust.yaml
@@ -1,0 +1,18 @@
+---
+name: "Lint Rust"
+
+on:  # yamllint disable-line rule:truthy
+  - pull_request
+  - push
+
+jobs:
+  lint_rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hecrj/setup-rust-action@v2
+        with:
+          rust-version: "stable"
+      - name: "Lint Rust"
+        run: "cargo fmt --all -- --check"
+...


### PR DESCRIPTION
PR to automatically run "cargo fmt" to verify that PRs do not add code that has not been formatted before.

# Example

````
# positive test on "master":
$ git switch master
$ cargo fmt --all -- --check
$ echo $?
0

# forced non-zero exit if you "break" arbitrary code by hand:
$ cargo fmt --all -- --check
Diff in /home/user/basilk/src/cli.rs:2:

 pub struct Cli;

-impl    Cli{
+impl Cli {
     pub fn read() {
         // If you use `cargo run main.rs`, skip must be 2
         let mut args = env::args().skip(1);
$ echo $?
1
````